### PR TITLE
Hotfixes/missing salt fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,27 @@
 ## Description
 This is a project my professor from System's Security had asked our class to do, each student had to pick a cipher and develop it.
 
-This project only encrypt and decrypt letters, all of the non aphabetic characters in the input file will NOT be read and encrypted. We'll also be using only uppercase, no need to type the message or password in uppercase though, the code already converts it ;)
+This project only encrypts and decrypts alphabetic letters. Any non-alphabetic characters in the input file will be ignored. We'll also be using only uppercase, no need to type the message or password in uppercase though, the code already converts it ;)
 
 ### Key Derivation
 
 This project uses the PBKDF2 algorithm (via Node.js `crypto` module) to securely derive a cryptographic key from the user-supplied key, following good security practices.
 
+The project also supports decrypting messages that were not encrypted with a salted key. However, using the key derivation process (PBKDF2 with salt) is strongly recommended for better security. The key derivation process involves hashing the password with a salt and multiple iterations to produce a secure key suitable for encryption and decryption.
+
+## Features
+- Encrypts and decrypts messages using the Vigenère cipher.
+- Handles non-alphabetic characters by ignoring them during encryption and decryption.
+- Outputs encrypted or decrypted messages to new files with appropriate naming conventions.
+- Uses PBKDF2 for key derivation to enhance security.
 ## Requirements
+To run this project, you need to have Node.js installed on your machine. You can download it from [Node.js official website](https://nodejs.org/).
+
 * Have node installed
 * Have a .txt file with the to-be-encrypted/decrypted message in the project folder
-## How to run
+## Usage
 We'll be using, for now, the terminal so we can run the script.<br>
-So go ahead and Open the project's folder on the terminal or navigate to it in the terminal.
+So go ahead and open the project's folder on the terminal or navigate to it in the terminal.
 
 The command we'll be typing will look like this:<br>
 `node vegenere.js <file.txt> <password> <mode>`<br>
@@ -24,21 +33,27 @@ The command we'll be typing will look like this:<br>
 
 ### Encrypt
 
-To encrypt you should have a text file with the message for encryption.<br>
-For this we'll use "to-decipher-file-name.txt" as a file example and "key" as password
+To encrypt, you should have a text file with the message you want to encrypt.  
+For this example, we'll use `to-cipher-file-name.txt` as the file and `key` as the password.
 
-* Enter `node vegenere.js to-cipher-file-name.txt key cipher` on the terminal
+```bash
+node vegenere.js to-cipher-file-name.txt key cipher
+```
 
 ### Decrypt
 
-To decrypt you should have a text file with the message for decryption.<br>
-For this we'll use "to-decipher-file-name.txt" as a file example and "key" as password
-* Enter `node vegenere.js to-decipher-file-name.txt key decipher` on the terminal
-Be sure to input the exact
-
+To decrypt, you should have a .txt file previously encrypted with this project, or formatted to match the expected structure.
+For this example, we'll use to-decipher-file-name.txt and the password key:
+```bash
+node vegenere.js to-decipher-file-name.txt key decipher
+```
+If the file includes a salt on the first line (as added during encryption), PBKDF2 will be used. Otherwise, the script will fall back to a classic Vigenère decryption using the raw key.
 
 ### Output
+The output files will be created in the same directory as the input file.<br>
+The output files will have the same name as the input file, but with `_cifrado` or `_decifrado` appended before the `.txt` extension, depending on whether you are encrypting or decrypting.
+
+### Example
 
 - The encrypted file will be saved as `<originalname>_cifrado.txt`
 - The decrypted file will be saved as `<originalname>_decifrado.txt`
-

--- a/src/cipher.js
+++ b/src/cipher.js
@@ -1,7 +1,7 @@
 function expandKey(key, messageLength) {
     let result = '';
     for (let i = 0; i < messageLength; i++) {
-        result += key[i % key.length];
+        result += key[i % key.length]; // Usa o operador módulo para repetir os caracteres da chave.
     }
     return result;
 }
@@ -9,9 +9,9 @@ function expandKey(key, messageLength) {
 function encrypt(message, expandedKey, letterToIndex, indexToLetter) {
     let result = '';
     for (let i = 0; i < message.length; i++) {
-        const m = letterToIndex[message[i]];
-        const k = letterToIndex[expandedKey[i]];
-        result += indexToLetter[(m + k) % 26];
+        const m = letterToIndex[message[i]]; // Obtém o índice da letra da mensagem.
+        const k = letterToIndex[expandedKey[i]]; // Obtém o índice da letra da chave expandida.
+        result += indexToLetter[(m + k) % 26]; // Calcula o índice da letra encriptada e converte de volta para uma letra.
     }
     return result;
 }
@@ -19,9 +19,9 @@ function encrypt(message, expandedKey, letterToIndex, indexToLetter) {
 function decrypt(message, expandedKey, letterToIndex, indexToLetter) {
     let result = '';
     for (let i = 0; i < message.length; i++) {
-        const m = letterToIndex[message[i]];
-        const k = letterToIndex[expandedKey[i]];
-        result += indexToLetter[(m - k + 26) % 26];
+        const m = letterToIndex[message[i]]; // Obtém o índice da letra da mensagem encriptada.
+        const k = letterToIndex[expandedKey[i]]; // Obtém o índice da letra da chave expandida.
+        result += indexToLetter[(m - k + 26) % 26]; // Calcula o índice da letra desencriptada e converte de volta para uma letra.
     }
     return result;
 }

--- a/src/keygen.js
+++ b/src/keygen.js
@@ -1,17 +1,21 @@
 const crypto = require('crypto');
 
+// Deriva uma chave criptográfica a partir de uma senha e um salt.
 function deriveKey(password, salt, iterations = 100000, keyLength = 32, digest = 'sha256') {
-    return crypto.pbkdf2Sync(password, salt, iterations, keyLength, digest);
+    return crypto.pbkdf2Sync(password, salt, iterations, keyLength, digest); // Retorna o buffer da chave derivada.
 }
 
+// Converte um buffer em uma sequência de letras.
+// Cada byte do buffer é mapeado para uma letra do alfabeto (A-Z) usando o operador módulo.
 function getDerivedLetters(buffer) {
     const letters = [];
     for (let i = 0; i < buffer.length; i++) {
-        const letterIndex = buffer[i] % 26;
-        const letter = String.fromCharCode(65 + letterIndex);
-        letters.push(letter);
+        const letterIndex = buffer[i] % 26; // Calcula o índice da letra com base no valor do byte.
+        const letter = String.fromCharCode(65 + letterIndex); // Converte o índice em uma letra (ASCII).
+        letters.push(letter); // Adiciona a letra ao array.
     }
-    return letters.join('');
+    return letters.join(''); // Junta as letras em uma string.
 }
 
+// Exporta as funções para uso em outros módulos.
 module.exports = { deriveKey, getDerivedLetters };

--- a/vegenere.js
+++ b/vegenere.js
@@ -63,7 +63,7 @@ else if (mode === 'decipher') {
     let derivedLetters;
 
     if (lines.length < 2) {
-        console.warn("\x1b[33m⚠️  Warning:\x1b[0m No salt detected. Using less secure classic mode without PBKDF2.\n");
+        console.warn("\x1b[33m⚠️  Warning:\x1b[0m No salt detected. Using less secure mode without PBKDF2.\n");
 
         encryptedMessage = lines[0];
         derivedLetters = key.toUpperCase().replace(/[^A-Z]/g, "").split('');

--- a/vegenere.js
+++ b/vegenere.js
@@ -42,7 +42,7 @@ let outputFile;
 if (mode === 'cipher') {
     const salt = crypto.randomBytes(16);
     const derivedKey = deriveKey(key, salt);
-    const derivedLetters = getDerivedLetters(derivedKey);
+    let derivedLetters = getDerivedLetters(derivedKey);
 
     const message = content.toUpperCase().replace(/[^A-Z]/g, "");
     const expandedKey = expandKey(derivedLetters, message.length);

--- a/vegenere.js
+++ b/vegenere.js
@@ -9,10 +9,6 @@ const key = process.argv[3];
 const mode = process.argv[4];
 
 if (!inputFile || !key || !mode) {
-    /* console.error("\x1b[31m❌ Error:\x1b[0m Missing arguments");
-    console.log("➜ Usage: node vegenere.js <input_file> <password> <mode>\n➜ Available Modes: 'cipher' and 'deipher'");
-    process.exit(1); */
-
     console.error("\x1b[31m❌ Missing required arguments.\x1b[0m\n");
     console.log("\x1b[1mUsage:\x1b[0m");
     console.log("  node vigenere.js <input_file.txt> <password> <mode>\n");
@@ -62,18 +58,20 @@ else if (mode === 'decipher') {
     let encryptedMessage;
     let derivedLetters;
 
-    if (lines.length < 2) {
-        console.warn("\x1b[33m⚠️  Warning:\x1b[0m No salt detected. Using less secure mode without PBKDF2.\n");
+    const isHex = /^[0-9a-fA-F]{32}$/.test(lines[0]);
 
-        encryptedMessage = lines[0];
-        derivedLetters = key.toUpperCase().replace(/[^A-Z]/g, "").split('');
-    } else {
+    if (isHex && lines.length > 1) {
         const saltHex = lines[0];
         const salt = Buffer.from(saltHex, 'hex');
         encryptedMessage = lines[1];
 
         const derivedKey = deriveKey(key, salt);
         derivedLetters = getDerivedLetters(derivedKey);
+    } else {
+        console.warn("\x1b[33m⚠️  Warning:\x1b[0m No salt detected. Using less secure mode without PBKDF2.\n");
+
+        encryptedMessage = lines.join('');
+        derivedLetters = key.toUpperCase().replace(/[^A-Z]/g, "").split('');
     }
 
     const message = encryptedMessage.toUpperCase().replace(/[^A-Z]/g, "");
@@ -86,6 +84,6 @@ else if (mode === 'decipher') {
     console.log(`➜ Output file: \x1b[1m${outputFile}\x1b[0m`);
 }
 else {
-    console.error("\x1b[31m❌ Error:\x1b[0m Invalid mode. Use 'cypher' or 'decipher'.");
+    console.error("\x1b[31m❌ Error:\x1b[0m Invalid mode. Use 'cipher' or 'decipher'.");
     process.exit(1);
 }

--- a/vegenere.js
+++ b/vegenere.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 const crypto = require('crypto');
 const { deriveKey, getDerivedLetters } = require('./src/keygen.js');
 const { expandKey, encrypt, decrypt } = require('./src/cipher.js');
-const { log } = require('console');
 
+//Recebe argumentos da linha de comando
 const inputFile = process.argv[2];
 const key = process.argv[3];
 const mode = process.argv[4];
@@ -29,13 +29,8 @@ for (let i = 0; i < 26; i++) {
     letterToIndex[letter] = i;
     indexToLetter[i] = letter;
 }
-/* ############################ */
-
-// Prepara a mensagem e a chave para cifragem/desifração
-// Remove caracteres não alfabéticos e converte para maiúsculas
 
 const content = fs.readFileSync(inputFile, 'utf8');
-
 let inputBase = inputFile.replace('.txt', '');
 let outputFile;
 
@@ -51,8 +46,7 @@ if (mode === 'cipher') {
     fs.writeFileSync(`${inputBase}_cifrado.txt`, salt.toString('hex') + '\n' + encryptedMessage);
     console.log("\x1b[32m✔️  Encryption complete!\x1b[0m");
     console.log(`➜ Output file: \x1b[1m${outputFile}\x1b[0m`);
-}
-else if (mode === 'decipher') {
+} else if (mode === 'decipher') {
     const lines = content.split('\n');
 
     let encryptedMessage;
@@ -60,12 +54,12 @@ else if (mode === 'decipher') {
 
     const isHex = /^[0-9a-fA-F]{32}$/.test(lines[0]);
 
-    if (isHex && lines.length > 1) {
+    if (isHex && lines.length > 1) { 
         const saltHex = lines[0];
         const salt = Buffer.from(saltHex, 'hex');
         encryptedMessage = lines[1];
 
-        const derivedKey = deriveKey(key, salt);
+        const derivedKey = deriveKey(key, salt); 
         derivedLetters = getDerivedLetters(derivedKey);
     } else {
         console.warn("\x1b[33m⚠️  Warning:\x1b[0m No salt detected. Using less secure mode without PBKDF2.\n");
@@ -82,8 +76,7 @@ else if (mode === 'decipher') {
     fs.writeFileSync(outputFile, decryptedMessage);
     console.log("\x1b[32m✔️  Decryption complete!\x1b[0m");
     console.log(`➜ Output file: \x1b[1m${outputFile}\x1b[0m`);
-}
-else {
+} else {
     console.error("\x1b[31m❌ Error:\x1b[0m Invalid mode. Use 'cipher' or 'decipher'.");
     process.exit(1);
 }

--- a/vegenere.js
+++ b/vegenere.js
@@ -2,14 +2,25 @@ const fs = require('fs');
 const crypto = require('crypto');
 const { deriveKey, getDerivedLetters } = require('./src/keygen.js');
 const { expandKey, encrypt, decrypt } = require('./src/cipher.js');
+const { log } = require('console');
 
 const inputFile = process.argv[2];
 const key = process.argv[3];
 const mode = process.argv[4];
 
 if (!inputFile || !key || !mode) {
-    console.error("Usage: node vegenere.js <input_file> <password> <mode>");
-    console.error("Available Modes: 'cipher' and 'deipher'");
+    /* console.error("\x1b[31m❌ Error:\x1b[0m Missing arguments");
+    console.log("➜ Usage: node vegenere.js <input_file> <password> <mode>\n➜ Available Modes: 'cipher' and 'deipher'");
+    process.exit(1); */
+
+    console.error("\x1b[31m❌ Missing required arguments.\x1b[0m\n");
+    console.log("\x1b[1mUsage:\x1b[0m");
+    console.log("  node vigenere.js <input_file.txt> <password> <mode>\n");
+    console.log("\x1b[1mExample:\x1b[0m");
+    console.log("  node vigenere.js message.txt mySecret cipher\n");
+    console.log("\x1b[1mModes:\x1b[0m");
+    console.log("  cipher     Encrypt the file");
+    console.log("  decipher   Decrypt a previously encrypted file\n");
     process.exit(1);
 }
 
@@ -42,6 +53,8 @@ if (mode === 'cipher') {
     encryptedMessage = encrypt(message, expandedKey, letterToIndex, indexToLetter);
     outputFile = `${inputBase}_cifrado.txt`;
     fs.writeFileSync(`${inputBase}_cifrado.txt`, salt.toString('hex') + '\n' + encryptedMessage);
+    console.log("\x1b[32m✔️  Encryption complete!\x1b[0m");
+    console.log(`➜ Output file: \x1b[1m${outputFile}\x1b[0m`);
 }
 else if (mode === 'decipher') {
     const lines = content.split('\n');
@@ -50,7 +63,8 @@ else if (mode === 'decipher') {
     let derivedLetters;
 
     if (lines.length < 2) {
-        console.warn("\nWarning!\nSalt was not detected on the input file. \nFalling back to less secure mode without PBKDF2.\n");
+        console.warn("\x1b[33m⚠️  Warning:\x1b[0m No salt detected. Using less secure classic mode without PBKDF2.\n");
+
         encryptedMessage = lines[0];
         derivedLetters = key.toUpperCase().replace(/[^A-Z]/g, "").split('');
     } else {
@@ -68,12 +82,10 @@ else if (mode === 'decipher') {
 
     outputFile = `${inputBase.replace('_cifrado', '')}_decifrado.txt`;
     fs.writeFileSync(outputFile, decryptedMessage);
+    console.log("\x1b[32m✔️  Decryption complete!\x1b[0m");
+    console.log(`➜ Output file: \x1b[1m${outputFile}\x1b[0m`);
 }
 else {
-    console.error("Invalid mode. Use 'cipher' or 'decipher'.");
+    console.error("\x1b[31m❌ Error:\x1b[0m Invalid mode. Use 'cypher' or 'decipher'.");
     process.exit(1);
 }
-
-console.log("All done!\n");
-
-console.log(`Output file: ${outputFile}`);


### PR DESCRIPTION
# Description
Fixes a bug I found during testing where if a file to be deciphered didn't have a first line with the salt, it would throw an error and not decipher the message.

## Solution
I added a case that, if the file does not have more than two lines, then it is just the ciphered message and will only utilize the user supplied password. 
I've also slid in a support for multiline files. 
Also added some comments for clarity on Cipher and keygen modules.